### PR TITLE
Remove the removal of new lines in the raw html

### DIFF
--- a/lib/html_parser/index.js
+++ b/lib/html_parser/index.js
@@ -38,11 +38,6 @@ function parse(htmlInput, prefix, postfix, cb) {
     function(tagValidatedHtml, cb) {
       attributeValidator.validate(tagValidatedHtml, cb);
     },
-    // remove blank lines
-    function(whitelistedHtml, cb) {
-      var html = whitelistedHtml.replace(/(\r\n|\n|\r)/gm, '');
-      cb(null, html);
-    },
     // namespace id and class attributes
     function(attributeSanitizedHtml, cb) {
       namespacer.namespace(attributeSanitizedHtml, prefix, postfix, cb);

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,24 @@ describe('library - html purifier', function() {
       done();
     });
   });
+
+  it('should not strip newlines from the html body', function(done) {
+    var options = { prefix: 'abc', postfix: 'ugc' };
+    var text = "<br><font size=2 face='sans-serif'>You are kindly requested to amend your\n" +
+      "Address book and/or bookmarks and start using the following new email addresses\r\n" +
+      "with immediate effect</font>\r" +
+      "<br>";
+
+    purify(text, options, function(err, res) {
+      expect(res).to.equal(
+        '<br class="ugc"><font size="2" face="sans-serif" class="ugc">'+
+        'You are kindly requested to amend your\nAddress book and/or'+
+        ' bookmarks and start using the following new email'+
+        ' addresses\r\nwith immediate effect</font>\r<br class="ugc">'
+      );
+      done();
+    });
+  })
 });
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -39,9 +39,9 @@ describe('library - html purifier', function() {
     var options = { prefix: 'abc', postfix: 'ugc' };
     var text = '@media only screen {div{display:block}\n';
     text = repeat(text, 100);
-    text = '<style type="text/css">\n' + text + '</style>\n';
+    text = '<style type="text/css">' + text + '</style>';
     text = repeat(text, 200);
-    text = '<style type="text/css">\nbody {padding: 0}\n</style>\n' + text; // something valid in this mess
+    text = '<style type="text/css">\nbody {padding: 0}</style>' + text; // something valid in this mess
     purify(text, options, function(err, res) {
       expect(res).to.equal('<style>body.ugc {\n  padding: 0;\n}</style>');
       done();


### PR DESCRIPTION
There may be a good reason that I'm unaware of for stripping new line characters in the html portion of the emails, but we can just remove this and I believe (and I tested) that the email will render as expected. I will open a branch on sedna with this as the npm module for the purifier and see how that plays out as well.  If there is a reason for this, feel free to let me know and we can take a different approach.  I would error on saying, generally we should leave their text alone as much as possible?
