### PR TITLE
SED-1586 Table formatting removed with inline image

### DIFF
--- a/lib/style_parser/index.js
+++ b/lib/style_parser/index.js
@@ -20,8 +20,12 @@ function parse(cssInput, prefix, postfix, cb) {
   async.waterfall([
     // remove everything except style tag contents
     function(cb) {
-      var requireStyleTags = true;
-      sanitizer.sanitize(cssInput, requireStyleTags, cb);
+      sanitizer.sanitize(cssInput, cb);
+    },
+    // add style tags
+    function(sanitizedHtml, cb) {
+      sanitizedHtml = addStyleTags(sanitizedHtml);
+      cb(null, sanitizedHtml);
     },
     // namespace sanitized style tag contents
     function(sanitizedHtml, cb) {
@@ -42,14 +46,13 @@ function parsePurified(cssInput, prefix, postfix, cb) {
   async.waterfall([
     // remove everything except style tag contents
     function(cb) {
-      var requireStyleTags = false;
-      sanitizer.sanitize(cssInput, requireStyleTags, cb);
+      sanitizer.sanitize(cssInput, cb);
     },
     // strip namespace
     function(sanitizedHtml, cb) {
       if ((typeof prefix !== 'undefined' || typeof postfix !== 'undefined') && sanitizedHtml !== '') {
         namespacer.stripNamespace(sanitizedHtml, prefix, postfix, function(err, stripped) {
-          strippedStyles = '<style>' + stripped + '</style>';
+          strippedStyles = addStyleTags(stripped);
           cb(null, strippedStyles);
         });
       } else {
@@ -59,6 +62,15 @@ function parsePurified(cssInput, prefix, postfix, cb) {
   ], cb);
 }
 
+/**
+ * Wraps the given input by adding HTML style tags.
+ *
+ * @param styles string The CSS styles to put inside the style tags
+ * @return string The CSS wrapped in style tags
+ */
+function addStyleTags(styles) {
+  return (styles) ? '<style>' + styles + '</style>' : '';
+}
 
 exports.parse = parse;
 exports.parsePurified = parsePurified;

--- a/lib/style_parser/index.js
+++ b/lib/style_parser/index.js
@@ -20,7 +20,8 @@ function parse(cssInput, prefix, postfix, cb) {
   async.waterfall([
     // remove everything except style tag contents
     function(cb) {
-      sanitizer.sanitize(cssInput, cb);
+      var requireStyleTags = true;
+      sanitizer.sanitize(cssInput, requireStyleTags, cb);
     },
     // namespace sanitized style tag contents
     function(sanitizedHtml, cb) {
@@ -41,32 +42,16 @@ function parsePurified(cssInput, prefix, postfix, cb) {
   async.waterfall([
     // remove everything except style tag contents
     function(cb) {
-      sanitizer.sanitize(cssInput, cb);
+      var requireStyleTags = false;
+      sanitizer.sanitize(cssInput, requireStyleTags, cb);
     },
     // strip namespace
     function(sanitizedHtml, cb) {
       if ((typeof prefix !== 'undefined' || typeof postfix !== 'undefined') && sanitizedHtml !== '') {
-        var re = /(?:<style>)([a-z0-9.\-{}:;\s#,]*)(?:<\/style>)/ig;
-        var match = true;
-        var strippedStyles = '';
-        var m;
-        async.whilst(function() {
-          return match;
-        }, function(cb) {
-          m = re.exec(sanitizedHtml);
-          if (m !== null) {
-            if (m.index === re.lastIndex) {
-              re.lastIndex++;
-            }
-            namespacer.stripNamespace(m[1], prefix, postfix, function(err, stripped) {
-              strippedStyles = strippedStyles + '<style>' + stripped + '</style>';
-              cb(null, strippedStyles);
-            });
-          } else {
-            match = false;
-            cb(null, strippedStyles);
-          }
-        }, cb);
+        namespacer.stripNamespace(sanitizedHtml, prefix, postfix, function(err, stripped) {
+          strippedStyles = '<style>' + stripped + '</style>';
+          cb(null, strippedStyles);
+        });
       } else {
         cb(null, sanitizedHtml);
       }

--- a/lib/style_parser/namespacer/postfixer.js
+++ b/lib/style_parser/namespacer/postfixer.js
@@ -37,29 +37,19 @@ function append(styles, postfix, cb) {
 function strip(styles, postfix, cb) {
   var obj = css.parse(styles);
   var sheet = obj.stylesheet;
-  var outputCache = [];
   var isReverted = false;
-  sheet.rules.forEach(function(rule) {
-    var selectors = [];
-    rule.selectors.forEach(function(selector) {
-      if (selector.indexOf(postfix) > -1) {
-        selectors.push(selector.replace(postfix, '').trim());
-        isReverted = true;
-      } else {
-        selectors.push(selector);
-      }
-    });
-    outputCache.push(selectors.join(', '));
-    outputCache.push(' { ');
-    var rules = [];
-    rule.declarations.forEach(function(declaration) {
-      rules.push(declaration.property + ': ' + declaration.value + '; ');
-    });
-    outputCache.push(rules.join('\n'));
-    outputCache.push('}');
+  sheet.rules.forEach(function(rule, ruleIndex) {
+    if (rule.type === 'rule') {
+      rule.selectors.forEach(function(selector, selectorIndex) {
+        if (selector.indexOf(postfix) > -1) {
+          obj.stylesheet.rules[ruleIndex].selectors[selectorIndex] = selector.replace(postfix, '').trim();
+          isReverted = true;
+        }
+      });
+    }
   });
 
-  cb(null, outputCache.join(''), isReverted);
+  cb(null, css.stringify(obj), isReverted);
 }
 
 

--- a/lib/style_parser/namespacer/prefixer.js
+++ b/lib/style_parser/namespacer/prefixer.js
@@ -26,28 +26,18 @@ function prepend(styles, prefix, cb) {
 function strip(styles, prefix, cb) {
   var obj = css.parse(styles);
   var sheet = obj.stylesheet;
-  var outputCache = [];
   var isReverted = false;
-  sheet.rules.forEach(function(rule) {
-    var selectors = [];
-    rule.selectors.forEach(function(selector) {
-      if (selector.indexOf(prefix) > -1) {
-        selectors.push(selector.replace(prefix, '').trim());
-        isReverted = true;
-      } else {
-        selectors.push(selector);
-      }
-    });
-    outputCache.push(selectors.join(', '));
-    outputCache.push(' { ');
-    var rules = [];
-    rule.declarations.forEach(function(declaration) {
-      rules.push(declaration.property + ': ' + declaration.value + '; ');
-    });
-    outputCache.push(rules.join('\n'));
-    outputCache.push('}');
+  sheet.rules.forEach(function(rule, ruleIndex) {
+    if (rule.type === 'rule') {
+      rule.selectors.forEach(function(selector, selectorIndex) {
+        if (selector.indexOf(prefix) > -1) {
+          obj.stylesheet.rules[ruleIndex].selectors[selectorIndex] = selector.replace(prefix, '').trim();
+          isReverted = true;
+        }
+      });
+    }
   });
-  cb(null, outputCache.join(''), isReverted);
+  cb(null, css.stringify(obj), isReverted);
 }
 
 

--- a/lib/style_parser/sanitizer/index.js
+++ b/lib/style_parser/sanitizer/index.js
@@ -14,12 +14,11 @@ var filterer = require('../filterer');
  *
  * @cb err, string
  * @param htmlInput string
- * @param requireStyleTags boolean
  * @pattern facade
  * @see http://code.google.com/p/google-caja/wiki/JsHtmlSanitizer
  * @see https://github.com/CLowbrow/node-caja-sanitizer
  */
-function sanitize(htmlInput, requireStyleTags, cb) {
+function sanitize(htmlInput, cb) {
   var outputCache = [];
 
   var omit = function(node) {
@@ -74,11 +73,7 @@ function sanitize(htmlInput, requireStyleTags, cb) {
   var styleGroups = [];
   outputCache2.forEach(function(theCss) {
     filterer.filter(theCss, function(err, cleanOutput) {
-      if (requireStyleTags){
-        var wrappedCssOutput = addStyleTags(cleanOutput);
-      } else {
-        var wrappedCssOutput = cleanOutput;
-      }
+      var wrappedCssOutput = cleanOutput;
       styleGroups.push(wrappedCssOutput);
     });
 
@@ -86,16 +81,6 @@ function sanitize(htmlInput, requireStyleTags, cb) {
 
   // join all style groups together
   cb(null, styleGroups.join(''));
-}
-
-/**
- * Wraps the given input by adding HTML style tags.
- *
- * @param styles string The CSS styles to put inside the style tags
- * @return string The CSS wrapped in style tags
- */
-function addStyleTags(styles) {
-  return (styles) ? '<style>' + styles + '</style>' : '';
 }
 
 

--- a/lib/style_parser/sanitizer/index.js
+++ b/lib/style_parser/sanitizer/index.js
@@ -14,11 +14,12 @@ var filterer = require('../filterer');
  *
  * @cb err, string
  * @param htmlInput string
+ * @param requireStyleTags boolean
  * @pattern facade
  * @see http://code.google.com/p/google-caja/wiki/JsHtmlSanitizer
  * @see https://github.com/CLowbrow/node-caja-sanitizer
  */
-function sanitize(htmlInput, cb) {
+function sanitize(htmlInput, requireStyleTags, cb) {
   var outputCache = [];
 
   var omit = function(node) {
@@ -73,7 +74,11 @@ function sanitize(htmlInput, cb) {
   var styleGroups = [];
   outputCache2.forEach(function(theCss) {
     filterer.filter(theCss, function(err, cleanOutput) {
-      var wrappedCssOutput = addStyleTags(cleanOutput);
+      if (requireStyleTags){
+        var wrappedCssOutput = addStyleTags(cleanOutput);
+      } else {
+        var wrappedCssOutput = cleanOutput;
+      }
       styleGroups.push(wrappedCssOutput);
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,7 @@ describe('library - html purifier', function() {
    * Tests for a 'RangeError: Maximum call stack size exceeded' exception, thrown by the
    * 'css' module that uses recursion when css tags are nested.
    */
+
   it('should discard nested selectors', function(done) {
     this.timeout(5000);
     var options = { prefix: 'abc', postfix: 'ugc' };
@@ -119,7 +120,7 @@ describe('library - html purifier', function() {
       var input = '<style>#xyz-link, #xyz-link2 #xyz-link3 #xyz-link4 #xyz-link5, p#xyz-test .abc{ margin-top:0; }</style><span class="abc xyz-hello">testing</span>';
       revert(input, options, function(err, res) {
         expect(err).to.not.be.an(Error);
-        expect(res).to.equal('<style>#link, #link2 #link3 #link4 #link5, p#test { margin-top: 0; }</style><span class="hello">testing</span>');
+        expect(res).to.equal('<style>#link,\n#link2 #link3 #link4 #link5,\np#test {\n  margin-top: 0;\n}</style><span class="hello">testing</span>');
         done();
       });
     });
@@ -183,7 +184,32 @@ describe('library - html purifier', function() {
 
       var clean = '<style>.ugc-ugc-ugc-ugc-ugc-ugc-cs95E872D0 { text-align: left; text-indent: 0pt;} .ugc-ugc-ugc-ugc-ugc-ugc-csA16174BA.ugc-ugc-ugc-ugc-ugc-ugc { color: #000000;} .ugc-ugc-ugc-ugc-ugc-ugc-cs5E98E930 { color: #000000; } .ugc-ugc-ugc-ugc-ugc-ugc-cs3FE84AE4 { color: #000000; }</style>';
 
-      var expected = '<style>.cs95E872D0 { text-align: left; \ntext-indent: 0pt; }.csA16174BA { color: #000000; }.cs5E98E930 { color: #000000; }.cs3FE84AE4 { color: #000000; }</style>';
+      var expected = '<style>.cs95E872D0 {\n  text-align: left;\n  text-indent: 0pt;\n}\n\n.csA16174BA {\n  color: #000000;\n}\n\n.cs5E98E930 {\n  color: #000000;\n}\n\n.cs3FE84AE4 {\n  color: #000000;\n}</style>';
+      revert(clean, options, function(err, res) {
+        expect(res).to.equal(expected);
+        done();
+      });
+    });
+
+    it('should parse style correctly', function(done) {
+      var options = { prefix: 'ugc-', postfix: 'ugc' };
+
+      var clean = '<style>.table{max-width:965px;font-size:12px;font-family:arial,helvetica;text-align:justify;border-collapse:collapse;border:1px solid black}.footer{font-size:12px;font-family:arial,helvetica;text-align:justify;border-collapse:collapse}.header{color:white;background:#00309B;font-family:arial,helvetica;font-weight:bold;text-align:center}.subheader{color:white;background:#00309B;font-family:arial,helvetica;text-align:center}.blankrow{height:6px;background-color:lightgray}.piccell{color:black;background-color:white;padding:0;text-align:left}.propcell{color:#00309B;background-color:white;white-space:nowrap;text-align:left;border:1px solid black;width:25%}.valcell{color:#00309B;background-color:white;white-space:nowrap;text-align:left;border:1px solid black;width:auto}.valcellgreen{color:#00309B;background-color:green;white-space:nowrap;text-align:left;border:1px solid black;width:25%}.valcellred{color:#00309B;background-color:red;white-space:nowrap;text-align:left;border:1px solid black;width:25%}.valcellorange{color:#00309B;background-color:orange;white-space:nowrap;text-align:left;border:1px solid black;width:25%}.relcellgreen{color:#00309B;background-color:green;white-space:nowrap;text-align:left;border:1px solid black;width:25%}.relcellred{color:#00309B;background-color:red;white-space:nowrap;text-align:left;border:1px solid black;width:25%}.relcellorange{color:#00309B;background-color:orange;white-space:nowrap;text-align:left;border:1px solid black;width:25%}</style>';
+
+      var expected = '<style>.table {\n  max-width: 965px;\n  font-size: 12px;\n  font-family: arial,helvetica;\n  text-align: justify;\n  border-collapse: collapse;\n  border: 1px solid black;\n}\n\n.footer {\n  font-size: 12px;\n  font-family: arial,helvetica;\n  text-align: justify;\n  border-collapse: collapse;\n}\n\n.header {\n  color: white;\n  background: #00309B;\n  font-family: arial,helvetica;\n  font-weight: bold;\n  text-align: center;\n}\n\n.subheader {\n  color: white;\n  background: #00309B;\n  font-family: arial,helvetica;\n  text-align: center;\n}\n\n.blankrow {\n  height: 6px;\n  background-color: lightgray;\n}\n\n.piccell {\n  color: black;\n  background-color: white;\n  padding: 0;\n  text-align: left;\n}\n\n.propcell {\n  color: #00309B;\n  background-color: white;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}\n\n.valcell {\n  color: #00309B;\n  background-color: white;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: auto;\n}\n\n.valcellgreen {\n  color: #00309B;\n  background-color: green;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}\n\n.valcellred {\n  color: #00309B;\n  background-color: red;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}\n\n.valcellorange {\n  color: #00309B;\n  background-color: orange;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}\n\n.relcellgreen {\n  color: #00309B;\n  background-color: green;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}\n\n.relcellred {\n  color: #00309B;\n  background-color: red;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}\n\n.relcellorange {\n  color: #00309B;\n  background-color: orange;\n  white-space: nowrap;\n  text-align: left;\n  border: 1px solid black;\n  width: 25%;\n}</style>';
+      revert(clean, options, function(err, res) {
+        expect(res).to.equal(expected);
+        done();
+      });
+    });
+
+    it('should parse style correctly when there are comments in style', function(done) {
+      var options = { prefix: 'ugc-', postfix: 'ugc' };
+
+      var clean = '<style><!--/* Font Definitions */@font-face {font-family:SimSun; panose-1:2 1 6 0 3 1 1 1 1 1;} @font-face {font-family:SimSun; panose-1:2 1 6 0 3 1 1 1 1 1;}/* Style Definitions */ p.ugc-MsoNormal, li.MsoNormal, div.ugc{margin:0in;margin-bottom:.0001pt; \font-size:11.0pt;font-family:"Calibri","serif";} </style>';
+
+      var expected = '<style>/* Font Definitions */\n\n@font-face {\n  font-family: SimSun;\n  panose-1: 2 1 6 0 3 1 1 1 1 1;\n}\n\n@font-face {\n  font-family: SimSun;\n  panose-1: 2 1 6 0 3 1 1 1 1 1;\n}\n\n/* Style Definitions */\n\np.MsoNormal,\nli.MsoNormal,\ndiv {\n  margin: 0in;\n  margin-bottom: .0001pt;\n  ont-size: 11.0pt;\n  font-family: "Calibri","serif";\n}</style>';
+
       revert(clean, options, function(err, res) {
         expect(res).to.equal(expected);
         done();

--- a/test/style_parser/index.js
+++ b/test/style_parser/index.js
@@ -19,7 +19,7 @@ describe('library - html purifier - style parser', function() {
     var PREFIX = 'ugc-';
     var POSTFIX = '.ugc';
     it('should remove prefix from multiple tags', function(done) {
-      var expected = '<style>#link, #link2 #link3 #link4 #link5, p#test { margin-top: 0; }</style>';
+      var expected = '<style>#link,\n#link2 #link3 #link4 #link5,\np#test {\n  margin-top: 0;\n}</style>';
       var clean = "<style>" +
         "#ugc-link, #ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5, p#ugc-test { margin-top:0; }" +
         "</style>";
@@ -31,7 +31,7 @@ describe('library - html purifier - style parser', function() {
     });
 
     it('should remove the prefix from multiple tags', function(done) {
-      var expected = '<style>.first.second.third { margin-top: 0; }</style>';
+      var expected = '<style>.first.second.third {\n  margin-top: 0;\n}</style>';
       var clean = '<style>.ugc-first.ugc-second.ugc-third {margin-top: 0;}</style>';
 
       styleParser.parsePurified(clean, PREFIX, POSTFIX, function(err, stripped) {
@@ -41,7 +41,7 @@ describe('library - html purifier - style parser', function() {
     });
 
     it('should remove the prefix from multiple class blocks', function(done) {
-      var expected = '<style>p.orig, div.test .link { margin-top: 0; }</style>';
+      var expected = '<style>p.orig,\ndiv.test .link {\n  margin-top: 0;\n}</style>';
       var clean = '<style>p.ugc-orig, div.ugc-test .ugc-link {margin-top: 0;}</style>';
 
       styleParser.parsePurified(clean, PREFIX, POSTFIX, function(err, stripped) {
@@ -51,7 +51,7 @@ describe('library - html purifier - style parser', function() {
     });
 
     it('should remove prefix from multiple tags', function(done) {
-      var expected = '<style>#link, #link2 #link3 #link4 #link5, p#test { margin-top: 0; }</style>';
+      var expected = '<style>#link,\n#link2 #link3 #link4 #link5,\np#test {\n  margin-top: 0;\n}</style>';
       var clean = '<style>#ugc-link, #ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5, p#ugc-test { margin-top: 0; }</style>';
 
       styleParser.parsePurified(clean, PREFIX, POSTFIX, function(err, stripped) {
@@ -63,7 +63,7 @@ describe('library - html purifier - style parser', function() {
     it('should support multiple style tags', function(done) {
       var html = '<style>P.ugc-p5 { margin-left: 1in; }</style><style>P.ugc-p6 { margin-left: 1in; }</style>';
       styleParser.parsePurified(html, PREFIX, POSTFIX, function(err, res) {
-        expect(res).to.equal('<style>P.p5 { margin-left: 1in; }</style><style>P.p6 { margin-left: 1in; }</style>');
+        expect(res).to.equal('<style>P.p5 {\n  margin-left: 1in;\n}\n\nP.p6 {\n  margin-left: 1in;\n}</style>');
         done();
       });
     });

--- a/test/style_parser/namespacer/postfixer.js
+++ b/test/style_parser/namespacer/postfixer.js
@@ -53,7 +53,7 @@ describe('lib - html purifier - style parser - namespacer - postfixer', function
     var POSTFIX = '.ugc';
 
     it('should remove postfix tag', function(done) {
-      var expected = 'a { color: #0000FF; }';
+      var expected = 'a {\n  color: #0000FF;\n}';
       var clean = 'a.ugc { color: #0000FF; }';
 
       postfixer.strip(clean, POSTFIX, function(err, stripped) {
@@ -63,7 +63,7 @@ describe('lib - html purifier - style parser - namespacer - postfixer', function
     });
 
     it('should remove postfix tag from pseudo-class', function(done) {
-      var expected = 'a:link { color: #0000FF; }';
+      var expected = 'a:link {\n  color: #0000FF;\n}';
       var clean = 'a.ugc:link { color: #0000FF; }';
 
       postfixer.strip(clean, POSTFIX, function(err, stripped) {
@@ -73,7 +73,7 @@ describe('lib - html purifier - style parser - namespacer - postfixer', function
     });
 
     it('should remove postfix tag with pseudo-class', function(done) {
-      var expected = 'a, p { color: #0000FF; }';
+      var expected = 'a,\np {\n  color: #0000FF;\n}';
       var clean = 'a.ugc, p.ugc { color: #0000FF; }';
 
       postfixer.strip(clean, POSTFIX, function(err, stripped) {
@@ -87,7 +87,7 @@ describe('lib - html purifier - style parser - namespacer - postfixer', function
       clean += 'margin-left: 1px;\n';
       clean += 'margin-right: 1px;\n';
       clean += '}\n';
-      var expected = 'P { margin-left: 1px; \nmargin-right: 1px; }';
+      var expected = 'P {\n  margin-left: 1px;\n  margin-right: 1px;\n}';
 
       postfixer.strip(clean, POSTFIX, function(err, stripped) {
         expect(stripped).to.equal(expected);

--- a/test/style_parser/namespacer/prefixer.js
+++ b/test/style_parser/namespacer/prefixer.js
@@ -105,7 +105,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should remove the prefix to just a class', function(done) {
       var clean = '.ugc-link { margin-top: 0; }';
-      var expected = '.link { margin-top: 0; }';
+      var expected = '.link {\n  margin-top: 0;\n}';
 
       prefixer.strip(clean, PREFIX, function(err, stripped) {
         expect(stripped).to.equal(expected);
@@ -115,7 +115,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should remove the prefix from a tag and class', function(done) {
       var clean = 'p.ugc-orig { margin-top: 0; }';
-      var expected = 'p.orig { margin-top: 0; }';
+      var expected = 'p.orig {\n  margin-top: 0;\n}';
 
       prefixer.strip(clean, PREFIX, function(err, stripped) {
         expect(stripped).to.equal(expected);
@@ -124,7 +124,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
     });
 
     it('should remove the prefix from an id', function(done) {
-      var expected = '#orig { margin-top: 0; }';
+      var expected = '#orig {\n  margin-top: 0;\n}';
       var clean = '#ugc-orig { margin-top: 0; }';
 
       prefixer.strip(clean, PREFIX, function(err, stripped) {
@@ -134,7 +134,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
     });
 
     it('should remove the prefix from id with tag', function(done) {
-      var expected = 'p#orig { margin-top: 0; }';
+      var expected = 'p#orig {\n  margin-top: 0;\n}';
       var clean = 'p#ugc-orig { margin-top: 0; }';
 
       prefixer.strip(clean, PREFIX, function(err, stripped) {
@@ -144,7 +144,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
     });
 
     it('should treat id that is a valid tag name as an id name', function(done) {
-      var expected = '#div { margin-top: 0; }';
+      var expected = '#div {\n  margin-top: 0;\n}';
       var clean = '#ugc-div { margin-top: 0; }';
 
       prefixer.strip(clean, PREFIX, function(err, stripped) {
@@ -158,7 +158,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
       clean += 'margin-left: 1px;\n';
       clean += 'margin-right: 1px;\n';
       clean += '}\n';
-      var expected = 'P.p5 { margin-left: 1px; \nmargin-right: 1px; }';
+      var expected = 'P.p5 {\n  margin-left: 1px;\n  margin-right: 1px;\n}';
 
       prefixer.strip(clean, PREFIX, function(err, stripped) {
         expect(stripped).to.equal(expected);

--- a/test/style_parser/sanitizer/index.js
+++ b/test/style_parser/sanitizer/index.js
@@ -12,10 +12,9 @@ describe('library - html purifier - style parser - sanitizer', function() {
 
   describe('sanitize()', function() {
     it('should remove title tags', function(done) {
-      var requireStyleTags = true;
       var dirty = '<title>hello world</title>';
 
-      sanitizer.sanitize(dirty, requireStyleTags, function(err, sanitized) {
+      sanitizer.sanitize(dirty, function(err, sanitized) {
         expect(err).to.be.equal(null);
         expect(sanitized).to.be.equal('');
         done();
@@ -23,12 +22,11 @@ describe('library - html purifier - style parser - sanitizer', function() {
     });
 
     it('should add style tags', function(done) {
-      var requireStyleTags = true;
       var dirty = '<style class="someHack">body { background: #fff }</style>';
 
-      sanitizer.sanitize(dirty, requireStyleTags, function(err, sanitized) {
+      sanitizer.sanitize(dirty, function(err, sanitized) {
         expect(err).to.be.equal(null);
-        expect(sanitized).to.be.equal('<style>body {\n  background: #fff;\n}</style>');
+        expect(sanitized).to.be.equal('body {\n  background: #fff;\n}');
         done();
       });
     });

--- a/test/style_parser/sanitizer/index.js
+++ b/test/style_parser/sanitizer/index.js
@@ -12,9 +12,10 @@ describe('library - html purifier - style parser - sanitizer', function() {
 
   describe('sanitize()', function() {
     it('should remove title tags', function(done) {
+      var requireStyleTags = true;
       var dirty = '<title>hello world</title>';
 
-      sanitizer.sanitize(dirty, function(err, sanitized) {
+      sanitizer.sanitize(dirty, requireStyleTags, function(err, sanitized) {
         expect(err).to.be.equal(null);
         expect(sanitized).to.be.equal('');
         done();
@@ -22,9 +23,10 @@ describe('library - html purifier - style parser - sanitizer', function() {
     });
 
     it('should add style tags', function(done) {
+      var requireStyleTags = true;
       var dirty = '<style class="someHack">body { background: #fff }</style>';
 
-      sanitizer.sanitize(dirty, function(err, sanitized) {
+      sanitizer.sanitize(dirty, requireStyleTags, function(err, sanitized) {
         expect(err).to.be.equal(null);
         expect(sanitized).to.be.equal('<style>body {\n  background: #fff;\n}</style>');
         done();


### PR DESCRIPTION
changed sanitizer to add style tags based on passed parameter requireStyleTags
in case of namespace sending requireStyleTags false, so that style tags are not added
removed regex to check for style tags
changed prefixed and postfixer to remove prefix and postfix in the original object , instead of trying to create new css which was causing different scenario issues
