### PR TITLE
SED-1759 Properly delete bad rules

### DIFF
--- a/lib/style_parser/filterer/index.js
+++ b/lib/style_parser/filterer/index.js
@@ -38,7 +38,7 @@ function handleParsingErrors(sheet) {
   var rules = sheet.stylesheet.rules;
   var rule;
   // remove the rules which have undefined declarations, these rules cause error with stringify
-  for( var ruleIndex = 0; ruleIndex<rules.length; ++ruleIndex) {
+  for (var ruleIndex = rules.length - 1; ruleIndex >= 0; ruleIndex--) {
     rule = rules[ruleIndex];
     if (typeof rule.declarations === 'undefined') {
       sheet.stylesheet.rules.splice(ruleIndex, 1);


### PR DESCRIPTION
`handleParsingErrors` is actually fairly broken, but its completely deleting things that it should not be deleting.

For example, it is currently deleting all rules of type "media", because those rules do not have declarations.

Note: Having a hard time coming up with a test that signifies the above. Help appreciated.
